### PR TITLE
feat(blog): Why Skills Beat Docs - Agent-Native Documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ Each skill maintains its own independent version. Use this matrix to understand 
 
 ## [Unreleased]
 
+### Website
+- **Added**: New blog post "Why Skills Beat Docs: The Rise of Agent-Native Documentation"
+  - Analysis of 100x engagement gap between docs and skills
+  - Comprehensive ecosystem overview (Skills.sh, Mintlify, awesome-claude-code)
+  - Step-by-step guide for converting docs to skills
+
 ### requesthunt
 - (no changes)
 

--- a/website/blog/blog.json
+++ b/website/blog/blog.json
@@ -1,6 +1,32 @@
 {
   "posts": [
     {
+      "slug": "why-skills-beat-docs",
+      "title": "Why Skills Beat Docs: The Rise of Agent-Native Documentation",
+      "description": "Traditional docs get 2 retweets. Skills get 350. That's 100x more engagement for the same content. Learn why agent-native documentation is the future and how to convert your docs to skills.",
+      "date": "2026-01-23",
+      "author": "OPC Team",
+      "category": "Insights",
+      "tags": ["agent-skills", "documentation", "ai-agents", "claude-code"],
+      "readTime": "6 min",
+      "keywords": ["agent skills", "AI documentation", "Claude Code skills", "Cursor skills", "skills.sh", "Mintlify", "agent-native docs"],
+      "image": "https://opc.dev/opc-banner.png",
+      "citations": [
+        {
+          "text": "swyx on Skills vs Docs engagement",
+          "url": "https://twitter.com/swyx/status/2014521220260364380"
+        },
+        {
+          "text": "Mintlify Skill.md Standard",
+          "url": "https://www.mintlify.com/blog/skill-md"
+        },
+        {
+          "text": "awesome-claude-code",
+          "url": "https://github.com/hesreallyhim/awesome-claude-code"
+        }
+      ]
+    },
+    {
       "slug": "domain-hunting-ai-saved-50",
       "title": "How Domain Hunter Skill Saved Me $50 on Domain Registration (5-Minute Tutorial)",
       "description": "Real case study: How Domain Hunter Skill compared 8 registrars and found active promo codes in 5 minutes. GoDaddy wanted $47.95/year, I paid $14.98. Includes exact workflow, price comparison table, and step-by-step tutorial you can replicate today.",

--- a/website/blog/posts/why-skills-beat-docs.md
+++ b/website/blog/posts/why-skills-beat-docs.md
@@ -1,0 +1,207 @@
+# Why Skills Beat Docs: The Rise of Agent-Native Documentation
+
+*By OPC Team | January 23, 2026 | 6 min read*
+
+## The Engagement Gap Nobody Talks About
+
+Last week, [swyx](https://twitter.com/swyx/status/2014521220260364380) (founder of AI Engineer, Latent Space podcast) dropped a fascinating observation:
+
+> "Publish markdown docs to docs website: 2 🔄 18 💙
+> 
+> Publish markdown docs as 'skills': 350 🔄 2.2k 💙 + omg wow what a forward thinking ai startup adopting best practices"
+
+That's roughly **100x more engagement** for the exact same content, just packaged differently.
+
+Why? Because we've entered the **Agent-Native Documentation** era—and traditional docs are becoming invisible.
+
+## What Are Agent Skills?
+
+Agent skills are structured markdown files that AI coding assistants can load, understand, and execute. Unlike traditional documentation that humans read, skills are designed for **both humans and AI agents** to consume.
+
+A typical skill includes:
+
+- **YAML frontmatter** with metadata (name, triggers, dependencies)
+- **Structured instructions** the AI can follow step-by-step
+- **Scripts and tools** for automation
+- **Examples** showing real-world usage
+
+Here's what a skill header looks like:
+
+```yaml
+---
+name: domain-hunter
+description: Search domains, compare registrar prices, find promo codes
+triggers:
+  - domain
+  - registrar
+  - buy domain
+dependencies:
+  - twitter
+  - reddit
+---
+```
+
+When you type "find me a domain for my startup" in Claude Code, Cursor, or Windsurf—the AI knows exactly which skill to invoke and how to execute it.
+
+## Why Skills Get 100x More Engagement
+
+### 1. Discoverability Through AI Agents
+
+Traditional docs require users to:
+1. Know your product exists
+2. Find your documentation site
+3. Read and understand the content
+4. Manually implement the solution
+
+Skills flip this entirely:
+1. User asks AI agent for help
+2. AI agent discovers and loads the relevant skill
+3. User gets immediate results
+
+Your skill becomes **discoverable through natural language queries** across millions of AI agent sessions.
+
+### 2. The "Install and Forget" Model
+
+[Skills.sh](https://skills.sh) (Vercel's skills aggregator) now shows installation counts and which AI platforms use each skill. One command:
+
+```bash
+npx skills add ReScienceLab/opc-skills --skill domain-hunter
+```
+
+And your AI permanently knows how to hunt domains, compare prices, and find promo codes. No reading required.
+
+### 3. Composability Creates Network Effects
+
+Skills can declare dependencies on other skills. Our `domain-hunter` skill depends on `twitter` and `reddit` skills for promo code discovery. This creates a **composable ecosystem** where skills enhance each other.
+
+As [yetone](https://twitter.com/yetone/status/2014561364195594486) (creator of openai-translator) noted: "opencode changed from skill to skills—standardization is happening!"
+
+## The Skills Ecosystem Explosion
+
+The past month has seen explosive growth in the skills ecosystem:
+
+### Major Players
+
+| Platform | Skills Support | Notes |
+|----------|---------------|-------|
+| Claude Code | Native | `.claude/skills/` directory |
+| Cursor | Native | `.cursor/skills/` directory |
+| Windsurf | Native | Project-level skills |
+| OpenCode | Native | Recently unified naming |
+| Codex (OpenAI) | Via adapters | Converting Claude skills |
+| Droid (Factory) | Native | `.factory/skills/` |
+
+### Tools Being Built
+
+- **[Skill Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Generate skills from any documentation
+- **[awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code)** - Curated skills, hooks, and plugins
+- **[Mintlify Skill.md](https://www.mintlify.com/blog/skill-md)** - Open standard for agent skills
+- **[claude-skills by nginity](https://github.com/alirezarezvani/claude-skills)** - Production-ready skill packages
+
+### Real Adoption
+
+Microsoft is now [testing Claude Code internally](https://reddit.com/r/ClaudeAI/comments/1qk4up5/microsoft_is_using_claude_code_internally_while/) (641 upvotes on Reddit). They're spending $500M/year with Anthropic while selling Copilot. When Microsoft's Windows, Teams, and M365 teams are using skills-based AI workflows, the writing is on the wall.
+
+## Docs vs Skills: A Technical Comparison
+
+| Aspect | Traditional Docs | Agent Skills |
+|--------|-----------------|--------------|
+| **Consumer** | Humans only | Humans + AI agents |
+| **Discovery** | SEO, direct links | Natural language queries |
+| **Execution** | Manual | Automated |
+| **Updates** | Re-read required | Re-install command |
+| **Composability** | Links only | Dependency system |
+| **Distribution** | Website hosting | npm/GitHub packages |
+| **Analytics** | Page views | Install counts + usage |
+
+## How to Convert Your Docs to Skills
+
+### Step 1: Identify Actionable Content
+
+Not all docs should become skills. Focus on:
+- Tutorials with clear steps
+- API integration guides
+- Workflow automation
+- Repeatable processes
+
+### Step 2: Add YAML Frontmatter
+
+```yaml
+---
+name: your-skill-name
+description: What this skill does in one sentence
+triggers:
+  - keyword1
+  - keyword2
+  - phrase that activates this skill
+dependencies: []
+---
+```
+
+### Step 3: Structure for AI Consumption
+
+- Use clear headings
+- Include code blocks with language tags
+- Add step-by-step numbered instructions
+- Provide example inputs and outputs
+
+### Step 4: Add Scripts (Optional but Powerful)
+
+```
+your-skill/
+├── SKILL.md           # Main instructions
+├── scripts/
+│   └── automate.py    # Executable automation
+└── examples/
+    └── workflow.md    # Real usage examples
+```
+
+### Step 5: Publish
+
+```bash
+# Users install with one command
+npx skills add your-org/your-repo --skill your-skill-name
+```
+
+## The Future: Agent-Native by Default
+
+We're witnessing a fundamental shift in how developer knowledge is packaged and distributed:
+
+- **2015-2020**: Static docs (Markdown + Jekyll/Docusaurus)
+- **2020-2024**: Interactive docs (Playground, live examples)
+- **2025+**: Agent-native docs (Skills that execute)
+
+The teams that adapt fastest will capture the most AI agent traffic. Your competitors' docs are invisible to AI agents. Your skills are not.
+
+## Get Started with OPC Skills
+
+OPC Skills is an open-source collection of 9 agent skills for solopreneurs:
+
+```bash
+# Install all skills
+npx skills add ReScienceLab/opc-skills
+
+# Or pick specific ones
+npx skills add ReScienceLab/opc-skills --skill domain-hunter
+npx skills add ReScienceLab/opc-skills --skill logo-creator
+```
+
+**Works with:** Claude Code, Cursor, Windsurf, Droid, and 12+ other AI platforms.
+
+**100% free and open source** under MIT license.
+
+[Explore OPC Skills on GitHub →](https://github.com/ReScienceLab/opc-skills)
+
+---
+
+## Further Reading
+
+- [What is OPC? AI Agent Skills for Solopreneurs Explained](/blog/what-is-opc)
+- [Domain Hunting Tutorial: How AI Saved Me $50](/blog/domain-hunting-ai-saved-50)
+- [Mintlify's Skill.md Specification](https://www.mintlify.com/blog/skill-md)
+- [swyx's Tweet on Skills vs Docs Engagement](https://twitter.com/swyx/status/2014521220260364380)
+- [awesome-claude-code Repository](https://github.com/hesreallyhim/awesome-claude-code)
+
+---
+
+*Have questions about agent skills? Join the discussion on [GitHub](https://github.com/ReScienceLab/opc-skills/discussions).*


### PR DESCRIPTION
## Summary
New blog post analyzing the 100x engagement gap between traditional docs and agent skills.

## Changes
- New blog post: `why-skills-beat-docs.md`
- Updated `blog.json` with SEO metadata
- Updated `CHANGELOG.md`

## Content Highlights
- swyx's observation: skills get 350 RTs vs docs get 2
- Ecosystem overview: Skills.sh, Mintlify, awesome-claude-code
- Step-by-step guide for converting docs to skills
- Platform compatibility table (Claude Code, Cursor, Windsurf, etc.)

## References
- https://twitter.com/swyx/status/2014521220260364380
- https://www.mintlify.com/blog/skill-md