### PR TITLE
feat(website): display skill installation counts from skills.sh

### DIFF
--- a/.github/workflows/fetch-install-stats.yml
+++ b/.github/workflows/fetch-install-stats.yml
@@ -1,0 +1,36 @@
+name: Fetch Install Stats
+
+on:
+  schedule:
+    - cron: '0 6 * * *'  # Daily at 6 AM UTC
+  workflow_dispatch:  # Manual trigger
+
+jobs:
+  fetch-stats:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Fetch install stats
+        run: python3 scripts/fetch-install-stats.py > website/install-stats.json
+
+      - name: Check for changes
+        id: diff
+        run: |
+          git diff --quiet website/install-stats.json || echo "changed=true" >> $GITHUB_OUTPUT
+
+      - name: Commit and push if changed
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add website/install-stats.json
+          git commit -m "chore: update install stats from skills.sh"
+          git push

--- a/scripts/fetch-install-stats.py
+++ b/scripts/fetch-install-stats.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Fetch installation stats from skills.sh and output JSON."""
+
+import json
+import re
+import sys
+import urllib.request
+
+SKILLS_SH_URL = "https://skills.sh/resciencelab/opc-skills"
+
+def fetch_install_stats():
+    """Scrape skills.sh page and extract installation counts."""
+    try:
+        req = urllib.request.Request(
+            SKILLS_SH_URL,
+            headers={"User-Agent": "OPC-Skills-Stats-Fetcher/1.0"}
+        )
+        with urllib.request.urlopen(req, timeout=30) as response:
+            html = response.read().decode("utf-8")
+    except Exception as e:
+        print(f"Error fetching {SKILLS_SH_URL}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Extract total installs (e.g., "266<!-- --> total installs")
+    total_match = re.search(r"(\d+)(?:<!--\s*-->)?\s*total\s*installs?", html, re.IGNORECASE)
+    total = int(total_match.group(1)) if total_match else 0
+
+    # Extract per-skill installs from skill links
+    # Pattern: skill name followed by install count in the link structure
+    skills = {}
+    
+    # HTML pattern: href="/resciencelab/opc-skills/{skill}">...<span...>{count}</span>
+    skill_pattern = re.compile(
+        r'href="/resciencelab/opc-skills/([a-z0-9-]+)"[^>]*>.*?'
+        r'<span[^>]*class="[^"]*font-mono[^"]*"[^>]*>(\d+)</span>',
+        re.IGNORECASE | re.DOTALL
+    )
+    
+    for match in skill_pattern.finditer(html):
+        skill_name = match.group(1).lower()
+        count = int(match.group(2))
+        # Skip template skill
+        if skill_name != "skill-name":
+            skills[skill_name] = count
+
+    result = {
+        "total": total,
+        "skills": skills,
+        "source": SKILLS_SH_URL
+    }
+    
+    return result
+
+if __name__ == "__main__":
+    stats = fetch_install_stats()
+    print(json.dumps(stats, indent=2))

--- a/website/install-stats.json
+++ b/website/install-stats.json
@@ -1,0 +1,15 @@
+{
+  "total": 266,
+  "skills": {
+    "nanobanana": 35,
+    "logo-creator": 33,
+    "reddit": 31,
+    "seo-geo": 29,
+    "domain-hunter": 27,
+    "requesthunt": 27,
+    "producthunt": 27,
+    "banner-creator": 26,
+    "twitter": 25
+  },
+  "source": "https://skills.sh/resciencelab/opc-skills"
+}


### PR DESCRIPTION
## Summary
Display installation counts from https://skills.sh/resciencelab/opc-skills on opc.dev homepage and skill detail pages.

## Changes
- Add `scripts/fetch-install-stats.py` to scrape install counts from skills.sh
- Add GitHub Action (`.github/workflows/fetch-install-stats.yml`) to run daily at 6 AM UTC
- Update `website/worker.js` to show install count badges on skill cards and detail pages
- Generate initial `website/install-stats.json`

## Screenshots
Skill cards will show: `nanobanana v1.0.0 35 installs`
Skill detail pages will show install count next to version.

Closes #12