### PR TITLE
fix(blog): reduce OG image thumbnail size on blog list

### DIFF
--- a/website/worker.js
+++ b/website/worker.js
@@ -2108,10 +2108,14 @@ async function renderBlogListPage(ctx) {
       display: block;
       width: 100%;
       border-bottom: 1px solid var(--black);
+      overflow: hidden;
+      max-height: 200px;
     }
     .blog-image {
       width: 100%;
-      height: auto;
+      height: 200px;
+      object-fit: cover;
+      object-position: center;
       display: block;
       transition: opacity 0.2s;
     }


### PR DESCRIPTION
## Summary

Fix oversized OG images on the blog list page by limiting them to 200px height thumbnails.

## Problem
OG images were displaying at full size (768px height), dominating the blog cards and making the page look unbalanced.

## Solution
- Set `max-height: 200px` on image container
- Use `height: 200px` with `object-fit: cover` for consistent sizing
- Center crop images with `object-position: center`
- Added `overflow: hidden` to prevent spillover

## Before vs After
**Before**: Images 768px tall, overwhelming the text content
**After**: Images 200px tall, properly sized as thumbnails

## Benefits
✅ Better visual balance
✅ More content visible without scrolling
✅ Images act as proper thumbnails, not full banners
✅ Consistent card heights

---

**Ready to merge!** Quick fix for image sizing. 🚀