### PR TITLE
feat(workflow): Add auto-close-issues workflow

### DIFF
--- a/.github/workflows/auto-close-issues.yml
+++ b/.github/workflows/auto-close-issues.yml
@@ -1,0 +1,89 @@
+name: Auto-close Issues on PR Merge
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  close-linked-issues:
+    # Only run if PR was actually merged (not just closed)
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    
+    steps:
+      - name: Extract issue numbers from PR
+        id: extract-issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const prTitle = context.payload.pull_request.title;
+            const prBody = context.payload.pull_request.body || '';
+            const prUrl = context.payload.pull_request.html_url;
+            
+            // Regex to find issue references like "Fixes #123", "Closes #456", "Resolves #789"
+            const issuePattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*#(\d+)/gi;
+            
+            const issueNumbers = new Set();
+            let match;
+            
+            // Search in PR title
+            while ((match = issuePattern.exec(prTitle)) !== null) {
+              issueNumbers.add(match[1]);
+            }
+            
+            // Search in PR body
+            issuePattern.lastIndex = 0; // Reset regex
+            while ((match = issuePattern.exec(prBody)) !== null) {
+              issueNumbers.add(match[1]);
+            }
+            
+            const issues = Array.from(issueNumbers);
+            console.log(`Found issues: ${issues.join(', ')}`);
+            
+            // Store for next step
+            core.setOutput('issue_numbers', issues.join(','));
+            core.setOutput('pr_number', prNumber);
+            core.setOutput('pr_url', prUrl);
+            core.setOutput('pr_title', prTitle);
+
+      - name: Comment and close issues
+        if: steps.extract-issues.outputs.issue_numbers != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumbers = '${{ steps.extract-issues.outputs.issue_numbers }}'.split(',');
+            const prNumber = '${{ steps.extract-issues.outputs.pr_number }}';
+            const prUrl = '${{ steps.extract-issues.outputs.pr_url }}';
+            const prTitle = `${{ steps.extract-issues.outputs.pr_title }}`;
+            
+            for (const issueNumber of issueNumbers) {
+              if (!issueNumber) continue;
+              
+              try {
+                // Add comment to the issue
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: parseInt(issueNumber),
+                  body: `✅ This issue has been automatically closed because PR #${prNumber} was merged.\n\n**PR Title:** ${prTitle}\n**PR Link:** ${prUrl}`
+                });
+                
+                console.log(`Added comment to issue #${issueNumber}`);
+                
+                // Close the issue
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: parseInt(issueNumber),
+                  state: 'closed'
+                });
+                
+                console.log(`Closed issue #${issueNumber}`);
+              } catch (error) {
+                console.error(`Error processing issue #${issueNumber}:`, error.message);
+              }
+            }


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow that automatically closes issues referenced in merged PRs and adds a comment indicating which PR caused the closure.

## Features
- ✅ **Auto-close on PR merge**: Only triggers when a PR is actually merged (not just closed)
- 💬 **Comment before closing**: Adds a comment to each issue with:
  - PR number and title
  - Direct link to the merged PR
- 🔍 **Smart detection**: Recognizes issue references using keywords:
  - `Fixes #123`
  - `Closes #456`
  - `Resolves #789`
  - Case-insensitive, works with variations (fixed, closed, resolved)
- 📝 **Searches both**: PR title and body for issue references
- ⚡ **Batch processing**: Handles multiple issues in one PR

## How It Works
1. Workflow triggers when a PR is closed
2. Checks if PR was merged (not just closed)
3. Extracts issue numbers from PR title and body using regex pattern
4. For each linked issue:
   - Adds a comment: "✅ This issue has been automatically closed because PR #X was merged"
   - Includes PR title and link
   - Closes the issue

## Example Comment
```
✅ This issue has been automatically closed because PR #28 was merged.

**PR Title:** feat(website): Complete SEO/GEO Phase 1, 2 & 3 optimizations
**PR Link:** https://github.com/ReScienceLab/opc-skills/pull/28
```

## Permissions
- `issues: write` - To comment on and close issues
- `pull-requests: read` - To read PR details

## Testing
After merging this PR, any future merged PR that references an issue (e.g., "Fixes #XX") will automatically close that issue with a descriptive comment.

## Benefits
- 🚀 Reduces manual issue management overhead
- 📊 Clear audit trail linking PRs to closed issues
- ✨ Improves contributor experience with automatic feedback
- 🤖 Consistent issue closure messages