### PR TITLE
Hotfix v1.0.2: Fix Claude Code Plugin Marketplace schema validation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -25,7 +25,7 @@
   "plugins": [
     {
       "name": "requesthunt",
-      "source": "requesthunt",
+      "source": "./requesthunt",
       "description": "Generate user demand research reports from real user feedback. Scrape and analyze feature requests, complaints, and questions from Reddit, X, and GitHub.",
       "version": "1.0.0",
       "homepage": "https://opc.dev/skills/requesthunt",
@@ -37,7 +37,7 @@
     },
     {
       "name": "domain-hunter",
-      "source": "domain-hunter",
+      "source": "./domain-hunter",
       "description": "Search domains, compare registrar prices, and find promo codes. Help users find and purchase domain names at the best price.",
       "version": "1.0.0",
       "homepage": "https://opc.dev/skills/domain-hunter",
@@ -49,7 +49,7 @@
     },
     {
       "name": "logo-creator",
-      "source": "logo-creator",
+      "source": "./logo-creator",
       "description": "Create logos using AI image generation. Discuss style/ratio, generate variations, iterate with user feedback, crop, remove background, and export as SVG.",
       "version": "1.0.0",
       "homepage": "https://opc.dev/skills/logo-creator",
@@ -61,7 +61,7 @@
     },
     {
       "name": "banner-creator",
-      "source": "banner-creator",
+      "source": "./banner-creator",
       "description": "Create banners using AI image generation. Discuss format/style, generate variations, iterate with user feedback, crop to target ratio for GitHub, Twitter, LinkedIn, etc.",
       "version": "1.0.0",
       "homepage": "https://opc.dev/skills/banner-creator",
@@ -73,7 +73,7 @@
     },
     {
       "name": "nanobanana",
-      "source": "nanobanana",
+      "source": "./nanobanana",
       "description": "Generate and edit images using Google Gemini 3 Pro Image (Nano Banana Pro). Supports text-to-image, image editing, aspect ratios, and 2K/4K output.",
       "version": "1.0.0",
       "homepage": "https://opc.dev/skills/nanobanana",
@@ -85,7 +85,7 @@
     },
     {
       "name": "reddit",
-      "source": "reddit",
+      "source": "./reddit",
       "description": "Search and retrieve content from Reddit. Get posts, comments, subreddit info, and user profiles via the public JSON API.",
       "version": "1.0.0",
       "homepage": "https://opc.dev/skills/reddit",
@@ -97,7 +97,7 @@
     },
     {
       "name": "twitter",
-      "source": "twitter",
+      "source": "./twitter",
       "description": "Search and retrieve content from Twitter/X. Get user info, tweets, replies, followers, communities, spaces, and trends via twitterapi.io.",
       "version": "1.0.0",
       "homepage": "https://opc.dev/skills/twitter",
@@ -109,7 +109,7 @@
     },
     {
       "name": "producthunt",
-      "source": "producthunt",
+      "source": "./producthunt",
       "description": "Search and retrieve content from Product Hunt. Get posts, topics, users, and collections via the GraphQL API.",
       "version": "1.0.0",
       "homepage": "https://opc.dev/skills/producthunt",
@@ -121,7 +121,7 @@
     },
     {
       "name": "seo-geo",
-      "source": "seo-geo",
+      "source": "./seo-geo",
       "description": "SEO & GEO (Generative Engine Optimization) for websites. Optimize for AI search engines (ChatGPT, Perplexity, Gemini, Copilot, Claude) and traditional search (Google, Bing).",
       "version": "1.0.0",
       "homepage": "https://opc.dev/skills/seo-geo",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,17 @@ Each skill maintains its own independent version. Use this matrix to understand 
 
 ## Released Versions
 
+## [1.0.2] - 2026-01-29
+
+### Infrastructure
+- **Fixed**: Claude Code Plugin Marketplace schema validation errors
+  - Updated all plugin source paths from bare names to relative paths (e.g., `"requesthunt"` → `"./requesthunt"`)
+  - Ensures compatibility with Claude Code's `/plugin marketplace add` command
+  - Resolves "Invalid input" errors when adding marketplace
+
+### Skills
+- (no skill version changes in this release)
+
 ## [1.0.1] - 2026-01-29
 
 ### Website

--- a/skills.json
+++ b/skills.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1",
+  "version": "1.0.2",
   "name": "OPC Skills",
   "description": "Agent Skills for One Person Companies",
   "repository": "https://github.com/ReScienceLab/opc-skills",


### PR DESCRIPTION
## Issue

When trying to add the marketplace with Claude Code:
```
/plugin marketplace add ReScienceLab/opc-skills
```

Users encountered schema validation errors:
```
Error: Invalid schema: plugins.0.source: Invalid input, plugins.1.source: Invalid input, ...
```

## Root Cause

Plugin source paths in `.claude-plugin/marketplace.json` were using bare names like `"requesthunt"` instead of relative paths like `"./requesthunt"`. According to Claude Code Plugin Marketplace documentation, source paths must be relative and start with `./`.

## Solution

Updated all 9 plugin entries in marketplace.json to use proper relative path format:
- `"source": "requesthunt"` → `"source": "./requesthunt"`
- `"source": "domain-hunter"` → `"source": "./domain-hunter"`
- And so on for all plugins

## Changes

- Fixed: All plugin source paths in `.claude-plugin/marketplace.json`
- Updated: Version from 1.0.1 → 1.0.2 in `skills.json`
- Updated: `CHANGELOG.md` with hotfix details

## Testing

After this fix, users can successfully add the marketplace:
```bash
/plugin marketplace add ReScienceLab/opc-skills
```