### PR TITLE
Hotfix v1.0.3: Fix blog OG image path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,16 @@ Each skill maintains its own independent version. Use this matrix to understand 
 
 ## Released Versions
 
+## [1.0.3] - 2026-01-29
+
+### Website
+- **Fixed**: Blog OG image path for installation tutorial post
+  - Corrected image path from `2026-01-28-install-tutorial-og.png` to `2026-01-28-install-opc-skills-claude-code-og.png`
+  - Fixes broken Open Graph preview on social media shares
+
+### Skills
+- (no skill version changes in this release)
+
 ## [1.0.2] - 2026-01-29
 
 ### Infrastructure

--- a/skills.json
+++ b/skills.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "name": "OPC Skills",
   "description": "Agent Skills for One Person Companies",
   "repository": "https://github.com/ReScienceLab/opc-skills",

--- a/website/blog/blog.json
+++ b/website/blog/blog.json
@@ -24,7 +24,7 @@
         "install domain hunter",
         "OPC Skills troubleshooting"
       ],
-      "image": "https://raw.githubusercontent.com/ReScienceLab/opc-skills/main/website/blog/2026-01-28-install-tutorial-og.png",
+      "image": "https://raw.githubusercontent.com/ReScienceLab/opc-skills/main/website/blog/2026-01-28-install-opc-skills-claude-code-og.png",
       "schema": {
         "@context": "https://schema.org",
         "@type": "HowTo",
@@ -71,7 +71,7 @@
             "url": "https://opc.dev/opc-logo.svg"
           }
         },
-        "image": "https://raw.githubusercontent.com/ReScienceLab/opc-skills/main/website/blog/2026-01-28-install-tutorial-og.png"
+        "image": "https://raw.githubusercontent.com/ReScienceLab/opc-skills/main/website/blog/2026-01-28-install-opc-skills-claude-code-og.png"
       },
       "faq": [
         {


### PR DESCRIPTION
## Issue
The installation tutorial blog post had incorrect OG image paths, causing broken previews when shared on social media.

## Fix
Updated the image path in both locations in blog.json:
- Main `image` field
- `schema.image` field

Changed from: `2026-01-28-install-tutorial-og.png`
Changed to: `2026-01-28-install-opc-skills-claude-code-og.png`

## Changes
- Fixed: OG image path in `website/blog/blog.json`
- Updated: Version 1.0.2 → 1.0.3 in `skills.json`
- Updated: `CHANGELOG.md` with hotfix details