### PR TITLE
Hotfix v1.0.4: Fix Claude Code marketplace cache issue

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Agent Skills for One Person Companies - Boost your AI agent with specialized skills for solopreneurs and indie hackers",
-    "version": "1.0.0",
+    "version": "1.0.3",
     "pluginRoot": "./skills"
   },
   "keywords": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,17 @@ Each skill maintains its own independent version. Use this matrix to understand 
 
 ## Released Versions
 
+## [1.0.4] - 2026-01-29
+
+### Infrastructure
+- **Fixed**: Updated marketplace metadata version to trigger cache refresh
+  - Changed marketplace metadata version from 1.0.0 to 1.0.3
+  - Fixes "Source path does not exist" error when installing plugins in Claude Code
+  - Ensures Claude Code refreshes marketplace cache with correct plugin paths
+
+### Skills
+- (no skill version changes in this release)
+
 ## [1.0.3] - 2026-01-29
 
 ### Website

--- a/skills.json
+++ b/skills.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.0.4",
   "name": "OPC Skills",
   "description": "Agent Skills for One Person Companies",
   "repository": "https://github.com/ReScienceLab/opc-skills",


### PR DESCRIPTION
## Issue
Users getting 'Source path does not exist' error when installing plugins in Claude Code.

## Root Cause
Marketplace metadata version was stuck at 1.0.0, causing Claude Code to use stale cached paths.

## Solution
- Updated marketplace metadata version from 1.0.0 to 1.0.3
- This triggers Claude Code to refresh its marketplace cache
- Ensures correct plugin paths are used during installation

## Changes
- Updated: `.claude-plugin/marketplace.json` metadata version
- Updated: Version 1.0.3 → 1.0.4 in `skills.json`
- Updated: `CHANGELOG.md` with hotfix details