### PR TITLE
fix: Update DeepWiki badge to official badge.svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <a href="https://opc.dev"><img src="https://img.shields.io/badge/Website-opc.dev-black?style=flat-square" alt="Website"></a>
   <a href="https://skills.sh/ReScienceLab/opc-skills"><img src="https://img.shields.io/badge/Browse-skills.sh-blue?style=flat-square" alt="Browse on skills.sh"></a>
-  <a href="https://deepwiki.com/ReScienceLab/opc-skills"><img src="https://img.shields.io/badge/DeepWiki-AI_Docs-purple?style=flat-square" alt="DeepWiki AI Documentation"></a>
+  <a href="https://deepwiki.com/ReScienceLab/opc-skills"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
   <a href="https://code.claude.com/docs/en/plugin-marketplaces"><img src="https://img.shields.io/badge/Claude_Code-Marketplace-orange?style=flat-square&logo=anthropic" alt="Claude Code Marketplace"></a>
   <a href="https://github.com/ReScienceLab/opc-skills/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=flat-square" alt="MIT License"></a>
   <a href="https://github.com/ReScienceLab/opc-skills/stargazers"><img src="https://img.shields.io/github/stars/ReScienceLab/opc-skills?style=flat-square" alt="GitHub Stars"></a>


### PR DESCRIPTION
## Summary

Update the DeepWiki badge to use the official badge provided by DeepWiki instead of a custom shields.io badge.

## Changes
- Replace `https://img.shields.io/badge/DeepWiki-AI_Docs-purple?style=flat-square` 
- With `https://deepwiki.com/badge.svg`
- Update alt text to "Ask DeepWiki"

## Why
- Uses DeepWiki's official branding
- Maintains consistency with DeepWiki's design guidelines
- Badge is maintained by DeepWiki (auto-updates if needed)

## Type
- [x] Hotfix
- [x] Documentation