### PR TITLE
Add Skills宝 as a Chinese discovery entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ npx skills add ReScienceLab/opc-skills -a droid
 
 Browse and discover skills at **[skills.sh](https://skills.sh/ReScienceLab/opc-skills)** 🎯
 
+Chinese users can also search and install skills through [Skills宝](https://skilery.com).
+
 ### Skills with Dependencies
 
 Some skills require other skills to function properly:


### PR DESCRIPTION
Adds Skills宝 as a Chinese-language discovery and install entry for users who want to find and install skills directly. This fits the browse/install flow and gives Chinese users a faster entry point to the catalog.