### PR TITLE
Fix: skills manifest entries should point to directory, not SKILL.md file

### DIFF
--- a/skills/banner-creator/.claude-plugin/plugin.json
+++ b/skills/banner-creator/.claude-plugin/plugin.json
@@ -19,7 +19,7 @@
     "readme banner"
   ],
   "skills": [
-    "./SKILL.md"
+    "./"
   ],
   "commands": [
     "./scripts/"

--- a/skills/domain-hunter/.claude-plugin/plugin.json
+++ b/skills/domain-hunter/.claude-plugin/plugin.json
@@ -17,6 +17,6 @@
     ".com domain"
   ],
   "skills": [
-    "./SKILL.md"
+    "./"
   ]
 }

--- a/skills/logo-creator/.claude-plugin/plugin.json
+++ b/skills/logo-creator/.claude-plugin/plugin.json
@@ -19,7 +19,7 @@
     "design logo"
   ],
   "skills": [
-    "./SKILL.md"
+    "./"
   ],
   "commands": [
     "./scripts/"

--- a/skills/nanobanana/.claude-plugin/plugin.json
+++ b/skills/nanobanana/.claude-plugin/plugin.json
@@ -17,7 +17,7 @@
     "AI image"
   ],
   "skills": [
-    "./SKILL.md"
+    "./"
   ],
   "commands": [
     "./scripts/"

--- a/skills/producthunt/.claude-plugin/plugin.json
+++ b/skills/producthunt/.claude-plugin/plugin.json
@@ -15,7 +15,7 @@
     "launch"
   ],
   "skills": [
-    "./SKILL.md"
+    "./"
   ],
   "commands": [
     "./scripts/"

--- a/skills/reddit/.claude-plugin/plugin.json
+++ b/skills/reddit/.claude-plugin/plugin.json
@@ -14,7 +14,7 @@
     "r/"
   ],
   "skills": [
-    "./SKILL.md"
+    "./"
   ],
   "commands": [
     "./scripts/"

--- a/skills/requesthunt/.claude-plugin/plugin.json
+++ b/skills/requesthunt/.claude-plugin/plugin.json
@@ -16,7 +16,7 @@
     "demand research"
   ],
   "skills": [
-    "./SKILL.md"
+    "./"
   ],
   "commands": [
     "./scripts/"

--- a/skills/seo-geo/.claude-plugin/plugin.json
+++ b/skills/seo-geo/.claude-plugin/plugin.json
@@ -21,7 +21,7 @@
     "Perplexity"
   ],
   "skills": [
-    "./SKILL.md"
+    "./"
   ],
   "commands": [
     "./scripts/"

--- a/skills/twitter/.claude-plugin/plugin.json
+++ b/skills/twitter/.claude-plugin/plugin.json
@@ -14,7 +14,7 @@
     "tweet"
   ],
   "skills": [
-    "./SKILL.md"
+    "./"
   ],
   "commands": [
     "./scripts/"


### PR DESCRIPTION
## Summary

All 9 skill plugins in this repo declare `"skills": ["./SKILL.md"]` in their `plugin.json`, but Claude Code's skill loader expects each entry to be a **directory** containing a `SKILL.md`, not a path to the file itself.

## Symptom

Running `/doctor` in Claude Code surfaces errors like:

```
nanobanana@opc-skills [nanobanana]: skills load failed from ./SKILL.md: path is a file; expected a directory
logo-creator@opc-skills [logo-creator]: skills load failed from ./SKILL.md: path is a file; expected a directory
seo-geo@opc-skills    [seo-geo]:    skills load failed from ./SKILL.md: path is a file; expected a directory
```

(Same error for the other 6 — only the 3 I had installed showed up in my `/doctor`, but the bug is identical in all 9 manifests.)

## Fix

For these single-skill plugins where the plugin root *is* the skill directory, change the entry from `"./SKILL.md"` to `"./"`.

Applied across all 9 plugins:
- banner-creator
- domain-hunter
- logo-creator
- nanobanana
- producthunt
- reddit
- requesthunt
- seo-geo
- twitter

## Test plan

- [ ] Install one of the affected plugins (e.g. `nanobanana`) in Claude Code
- [ ] Run `/doctor` — confirm no `skills load failed` error for the plugin
- [ ] Confirm the skill is discoverable via the `Skill` tool / skill listing