### PR TITLE
feat(logo-creator): add optional Atlas Cloud provider

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -61,8 +61,8 @@
     {
       "name": "logo-creator",
       "source": "./skills/logo-creator",
-      "description": "Create logos using AI image generation. Discuss style/ratio, generate variations, iterate with user feedback, crop, remove background, and export as SVG.",
-      "version": "1.0.0",
+      "description": "Create logos using optional Nano Banana or Atlas Cloud image generation, then iterate, crop, remove backgrounds, and export as SVG.",
+      "version": "1.1.0",
       "homepage": "https://opc.dev/skills/logo-creator",
       "repository": "https://github.com/ReScienceLab/opc-skills",
       "license": "MIT",

--- a/skills.json
+++ b/skills.json
@@ -180,8 +180,8 @@
     },
     {
       "name": "logo-creator",
-      "version": "1.0.0",
-      "description": "Create logos using AI image generation. Discuss style/ratio, generate variations, iterate with user feedback, crop, remove background, and export as SVG.",
+      "version": "1.1.0",
+      "description": "Create logos using optional Nano Banana or Atlas Cloud image generation, then iterate, crop, remove backgrounds, and export as SVG.",
       "logo": "https://raw.githubusercontent.com/ReScienceLab/opc-skills/main/skill-logos/logo-creator.svg",
       "icon": "image",
       "color": "8B5CF6",
@@ -205,6 +205,11 @@
           {
             "env": "GEMINI_API_KEY",
             "url": "https://aistudio.google.com/apikey"
+          },
+          {
+            "env": "ATLASCLOUD_API_KEY",
+            "url": "https://www.atlascloud.ai/console/api-keys",
+            "optional": true
           },
           {
             "env": "REMOVE_BG_API_KEY",
@@ -235,6 +240,7 @@
       },
       "commands": [
         "python3 <nanobanana>/scripts/batch_generate.py \"{prompt}\" -n 20 --ratio 1:1 -d ./logos -p logo",
+        "python3 scripts/generate_atlas.py \"{prompt}\" {output.png} --ratio 1:1 --dry-run",
         "python3 scripts/crop_logo.py {input.png} {output.png}",
         "python3 scripts/remove_bg.py {input.png} {output.png}",
         "python3 scripts/vectorize.py {input.png} {output.svg}"

--- a/skills/logo-creator/.claude-plugin/plugin.json
+++ b/skills/logo-creator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "logo-creator",
-  "version": "1.0.0",
-  "description": "Create logos using AI image generation. Discuss style/ratio, generate variations, iterate with user feedback, crop, remove background, and export as SVG.",
+  "version": "1.1.0",
+  "description": "Create logos using optional Nano Banana or Atlas Cloud image generation, then iterate, crop, remove backgrounds, and export as SVG.",
   "author": {
     "name": "ReScienceLab"
   },

--- a/skills/logo-creator/SKILL.md
+++ b/skills/logo-creator/SKILL.md
@@ -5,17 +5,22 @@ description: Create logos using AI image generation. Discuss style/ratio, genera
 
 # Logo Creator Skill
 
-Create professional logos through AI image generation with an iterative design process.
+Create professional logos through AI image generation with an iterative design process. Keep the existing Nano Banana path as the default, and use Atlas Cloud only when the user selects it or already has Atlas credentials configured.
 
 ## Prerequisites
 
-**Required API Keys (set in environment):**
-- `GEMINI_API_KEY` - Get from [Google AI Studio](https://aistudio.google.com/apikey)
+**Generation API key (choose one provider):**
+- `GEMINI_API_KEY` - Existing default via [Google AI Studio](https://aistudio.google.com/apikey)
+- `ATLASCLOUD_API_KEY` - Optional Atlas Cloud provider via the [Atlas Cloud console](https://www.atlascloud.ai/console/api-keys)
+
+**Optional post-processing API keys:**
 - `REMOVE_BG_API_KEY` - Get from [remove.bg](https://www.remove.bg/api)
 - `RECRAFT_API_KEY` - Get from [recraft.ai](https://www.recraft.ai/)
 
-**Required Skills:**
+**Required Skill for the default provider:**
 - `nanobanana` - AI image generation (Gemini 3 Pro Image)
+
+Atlas Cloud does not require the `nanobanana` skill. Its bundled script discovers the current model catalog, validates the selected model's live schema, submits exactly one generation request, polls with a finite budget, and downloads the completed image.
 
 
 
@@ -80,7 +85,13 @@ Before generating, gather requirements from user:
 
 ### Step 2: Generate Logo Variations
 
-Generate 20 logo variations (default) using the `nanobanana` skill:
+Choose the generation provider before making any paid request. Keep Nano Banana as the default. Offer Atlas Cloud as an optional provider when the user requests Atlas, has `ATLASCLOUD_API_KEY` configured, or wants to choose among Atlas-hosted image models.
+
+Treat each generation request as potentially billable. Confirm the provider, current unit price, exact payload, and number of images before submission. Never automatically retry a generation `POST` after a timeout or ambiguous response.
+
+### Nano Banana (default)
+
+Generate logo variations using the `nanobanana` skill:
 
 ```bash
 # Generate single logo
@@ -102,6 +113,30 @@ python3 <nanobanana_skill_dir>/scripts/batch_generate.py "{style} logo for {bran
 - Specify colors: "black on white", "monochrome", "blue gradient"
 - Add context: "tech startup", "food brand", "gaming company"
 - Request format: "icon", "emblem", "mascot", "lettermark"
+
+### Atlas Cloud (optional)
+
+Resolve the absolute path of this skill directory, then validate the live catalog and model schema without spending credits:
+
+```bash
+python3 <skill_dir>/scripts/generate_atlas.py \
+  "{style} logo for {brand}, {description}, {colors}, no watermark" \
+  .skill-archive/logo-creator/<date-name>/logo-01.png \
+  --ratio 1:1 \
+  --dry-run
+```
+
+Show the returned payload and current base price to the user. After the user explicitly approves that request, submit one image:
+
+```bash
+python3 <skill_dir>/scripts/generate_atlas.py \
+  "{style} logo for {brand}, {description}, {colors}, no watermark" \
+  .skill-archive/logo-creator/<date-name>/logo-01.png \
+  --ratio 1:1 \
+  --confirm-generation
+```
+
+The default Atlas model is `google/nano-banana-2/text-to-image`, but the script accepts `--model` only after verifying an exact live Image catalog match and its schema. Run one command per approved image so a failed or timed-out submission cannot silently create duplicate paid jobs. Prediction `GET` polling is bounded; if it expires, preserve the prediction ID and check that job later instead of submitting a replacement.
 
 ### Step 3: Create HTML Preview
 

--- a/skills/logo-creator/scripts/generate_atlas.py
+++ b/skills/logo-creator/scripts/generate_atlas.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Generate one logo image through Atlas Cloud's asynchronous media API."""
+
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import json
+import os
+from pathlib import Path
+import socket
+import sys
+import tempfile
+import time
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+
+API_BASE = "https://api.atlascloud.ai"
+CATALOG_URL = f"{API_BASE}/api/v1/models"
+GENERATE_URL = f"{API_BASE}/api/v1/model/generateImage"
+PREDICTION_URL = f"{API_BASE}/api/v1/model/prediction/{{prediction_id}}"
+DEFAULT_MODEL = "google/nano-banana-2/text-to-image"
+SCHEMA_PREFIX = "https://static.atlascloud.ai/model/schema/"
+MAX_DOWNLOAD_BYTES = 25 * 1024 * 1024
+TERMINAL_FAILURES = {"failed", "canceled", "cancelled", "timeout"}
+
+
+class AtlasError(RuntimeError):
+    """A safe, user-facing Atlas integration error."""
+
+
+def request_json(
+    url: str,
+    *,
+    method: str = "GET",
+    headers: dict[str, str] | None = None,
+    payload: dict[str, Any] | None = None,
+    timeout: float = 30,
+) -> dict[str, Any]:
+    body = None if payload is None else json.dumps(payload).encode("utf-8")
+    request_headers = {
+        "Accept": "application/json",
+        "User-Agent": "opc-logo-creator/1.1",
+        **(headers or {}),
+    }
+    request = Request(url, data=body, method=method, headers=request_headers)
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            value = json.load(response)
+    except (HTTPError, URLError, TimeoutError, json.JSONDecodeError) as exc:
+        raise AtlasError(f"{method} {url} failed: {exc}") from exc
+    if not isinstance(value, dict):
+        raise AtlasError(f"{method} {url} returned a non-object JSON response")
+    return value
+
+
+def unwrap_data(value: dict[str, Any]) -> dict[str, Any]:
+    data = value.get("data")
+    return data if isinstance(data, dict) else value
+
+
+def find_model(catalog: dict[str, Any], model: str) -> dict[str, Any]:
+    entries = catalog.get("data")
+    if not isinstance(entries, list):
+        raise AtlasError("Atlas model catalog has no data array")
+    matches = [entry for entry in entries if isinstance(entry, dict) and entry.get("model") == model]
+    if len(matches) != 1:
+        raise AtlasError(f"model must match exactly one live catalog entry: {model}")
+    entry = matches[0]
+    if entry.get("type") != "Image":
+        raise AtlasError(f"model is not an Image model: {model}")
+    schema_url = entry.get("schema")
+    if not isinstance(schema_url, str) or not schema_url.startswith(SCHEMA_PREFIX):
+        raise AtlasError("model catalog returned an unexpected schema URL")
+    return entry
+
+
+def validate_payload(schema: dict[str, Any], payload: dict[str, Any]) -> None:
+    input_schema = schema.get("components", {}).get("schemas", {}).get("Input")
+    if not isinstance(input_schema, dict):
+        raise AtlasError("model schema has no components.schemas.Input object")
+    properties = input_schema.get("properties")
+    required = input_schema.get("required", [])
+    if not isinstance(properties, dict) or not isinstance(required, list):
+        raise AtlasError("model input schema is malformed")
+
+    unknown = sorted(set(payload) - set(properties))
+    if unknown:
+        raise AtlasError(f"payload contains fields absent from the live schema: {', '.join(unknown)}")
+    missing = [name for name in required if name not in payload]
+    if missing:
+        raise AtlasError(f"payload is missing required fields: {', '.join(missing)}")
+
+    for name, value in payload.items():
+        definition = properties.get(name)
+        if not isinstance(definition, dict):
+            continue
+        allowed = definition.get("enum")
+        if isinstance(allowed, list) and value not in allowed:
+            choices = ", ".join(str(item) for item in allowed)
+            raise AtlasError(f"{name} must be one of: {choices}")
+
+
+def build_payload(args: argparse.Namespace) -> dict[str, Any]:
+    return {
+        "model": args.model,
+        "prompt": args.prompt,
+        "aspect_ratio": args.ratio,
+        "resolution": args.resolution,
+        "output_format": args.output_format,
+    }
+
+
+def auth_headers(api_key: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+
+def submit_once(payload: dict[str, Any], api_key: str) -> dict[str, Any]:
+    response = request_json(
+        GENERATE_URL,
+        method="POST",
+        headers=auth_headers(api_key),
+        payload=payload,
+        timeout=60,
+    )
+    code = response.get("code")
+    if code is not None and str(code) not in {"0", "200"}:
+        detail = response.get("message") or response.get("msg") or "unknown API error"
+        raise AtlasError(f"generation API rejected the request: {detail}")
+    prediction = unwrap_data(response)
+    prediction_id = prediction.get("id")
+    if not isinstance(prediction_id, str) or not prediction_id:
+        raise AtlasError(
+            "generation response contained no prediction ID; submission is ambiguous and must not be retried"
+        )
+    return prediction
+
+
+def poll_prediction(
+    prediction_id: str,
+    api_key: str,
+    *,
+    attempts: int,
+    interval: float,
+) -> dict[str, Any]:
+    url = PREDICTION_URL.format(prediction_id=prediction_id)
+    last_error: AtlasError | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            prediction = unwrap_data(
+                request_json(url, headers=auth_headers(api_key), timeout=30)
+            )
+            last_error = None
+        except AtlasError as exc:
+            last_error = exc
+            prediction = {}
+
+        status = str(prediction.get("status", "")).lower()
+        if status in {"completed", "succeeded"}:
+            outputs = prediction.get("outputs")
+            if not isinstance(outputs, list) or not outputs or not isinstance(outputs[0], str):
+                raise AtlasError("completed prediction contained no output URL")
+            return prediction
+        if status in TERMINAL_FAILURES:
+            detail = prediction.get("error") or prediction.get("message") or status
+            raise AtlasError(f"prediction ended with {status}: {detail}")
+        if attempt < attempts:
+            time.sleep(interval)
+
+    suffix = f": {last_error}" if last_error else ""
+    raise AtlasError(
+        f"polling budget exhausted for prediction {prediction_id}{suffix}; do not submit a replacement job"
+    )
+
+
+def validate_public_https(url: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or not parsed.hostname or parsed.username or parsed.password:
+        raise AtlasError("output URL must be credential-free HTTPS")
+    try:
+        addresses = socket.getaddrinfo(parsed.hostname, parsed.port or 443, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise AtlasError(f"could not resolve output host: {exc}") from exc
+    for address in addresses:
+        ip = ipaddress.ip_address(address[4][0])
+        if not ip.is_global:
+            raise AtlasError("output URL resolves to a non-public address")
+
+
+def image_kind(header: bytes) -> str | None:
+    if header.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "png"
+    if header.startswith(b"\xff\xd8\xff"):
+        return "jpeg"
+    if len(header) >= 12 and header[:4] == b"RIFF" and header[8:12] == b"WEBP":
+        return "webp"
+    return None
+
+
+def download_image(url: str, output: Path) -> None:
+    validate_public_https(url)
+    request = Request(
+        url,
+        headers={"Accept": "image/*", "User-Agent": "opc-logo-creator/1.1"},
+    )
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temp_path: Path | None = None
+    try:
+        with urlopen(request, timeout=60) as response:
+            final_url = response.geturl()
+            validate_public_https(final_url)
+            content_type = response.headers.get_content_type()
+            with tempfile.NamedTemporaryFile(dir=output.parent, delete=False) as handle:
+                temp_path = Path(handle.name)
+                total = 0
+                header = b""
+                while True:
+                    chunk = response.read(64 * 1024)
+                    if not chunk:
+                        break
+                    total += len(chunk)
+                    if total > MAX_DOWNLOAD_BYTES:
+                        raise AtlasError("output image exceeds the 25 MiB limit")
+                    if len(header) < 16:
+                        header = (header + chunk)[:16]
+                    handle.write(chunk)
+        if not content_type.startswith("image/") or image_kind(header) is None:
+            raise AtlasError("downloaded output is not a recognized image")
+        os.replace(temp_path, output)
+        temp_path = None
+    except (HTTPError, URLError, TimeoutError, OSError) as exc:
+        raise AtlasError(f"image download failed: {exc}") from exc
+    finally:
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("prompt", help="Complete logo-generation prompt")
+    parser.add_argument("output", type=Path, help="Output image path")
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--ratio", default="1:1")
+    parser.add_argument("--resolution", default="1k")
+    parser.add_argument("--output-format", default="png")
+    parser.add_argument("--poll-attempts", type=int, default=40)
+    parser.add_argument("--poll-interval", type=float, default=3.0)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--dry-run", action="store_true", help="Validate live model/schema without submitting")
+    mode.add_argument(
+        "--confirm-generation",
+        action="store_true",
+        help="Acknowledge that this command submits one potentially billable generation",
+    )
+    args = parser.parse_args(argv)
+    if args.poll_attempts < 1 or args.poll_interval < 0:
+        parser.error("poll attempts must be positive and interval must be non-negative")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = build_payload(args)
+    try:
+        catalog = request_json(CATALOG_URL)
+        entry = find_model(catalog, args.model)
+        schema = request_json(entry["schema"])
+        validate_payload(schema, payload)
+        price = entry.get("price", {}).get("actual", {}).get("base_price")
+
+        if args.dry_run:
+            print(json.dumps({"payload": payload, "current_base_price": price}, indent=2))
+            return 0
+
+        api_key = os.environ.get("ATLASCLOUD_API_KEY")
+        if not api_key:
+            raise AtlasError("ATLASCLOUD_API_KEY is not set")
+        prediction = submit_once(payload, api_key)
+        prediction_id = prediction["id"]
+        print(f"Submitted prediction: {prediction_id}", file=sys.stderr)
+        completed = poll_prediction(
+            prediction_id,
+            api_key,
+            attempts=args.poll_attempts,
+            interval=args.poll_interval,
+        )
+        download_image(completed["outputs"][0], args.output)
+        print(str(args.output.resolve()))
+        return 0
+    except AtlasError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/logo-creator/tests/test_generate_atlas.py
+++ b/skills/logo-creator/tests/test_generate_atlas.py
@@ -1,0 +1,137 @@
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import patch
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "generate_atlas.py"
+SPEC = importlib.util.spec_from_file_location("generate_atlas", SCRIPT)
+assert SPEC and SPEC.loader
+atlas = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = atlas
+SPEC.loader.exec_module(atlas)
+
+
+class FakeResponse:
+    def __init__(self, body, *, url="https://cdn.example.com/logo.png", content_type="application/json"):
+        self.body = body if isinstance(body, bytes) else json.dumps(body).encode()
+        self.url = url
+        self.headers = type("Headers", (), {"get_content_type": lambda self: content_type})()
+        self.offset = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def read(self, size=-1):
+        if size == -1:
+            result = self.body[self.offset :]
+            self.offset = len(self.body)
+            return result
+        result = self.body[self.offset : self.offset + size]
+        self.offset += len(result)
+        return result
+
+    def geturl(self):
+        return self.url
+
+
+class AtlasGeneratorTests(unittest.TestCase):
+    def test_find_model_requires_exact_image_entry(self):
+        catalog = {
+            "data": [
+                {
+                    "model": atlas.DEFAULT_MODEL,
+                    "type": "Image",
+                    "schema": atlas.SCHEMA_PREFIX + "model.json",
+                }
+            ]
+        }
+        self.assertEqual(atlas.find_model(catalog, atlas.DEFAULT_MODEL)["type"], "Image")
+        with self.assertRaises(atlas.AtlasError):
+            atlas.find_model(catalog, "missing")
+
+    def test_validate_payload_rejects_unknown_and_invalid_enum(self):
+        schema = {
+            "components": {
+                "schemas": {
+                    "Input": {
+                        "required": ["model", "prompt"],
+                        "properties": {
+                            "model": {"type": "string"},
+                            "prompt": {"type": "string"},
+                            "aspect_ratio": {"enum": ["1:1", "16:9"]},
+                        },
+                    }
+                }
+            }
+        }
+        atlas.validate_payload(schema, {"model": "m", "prompt": "p", "aspect_ratio": "1:1"})
+        with self.assertRaises(atlas.AtlasError):
+            atlas.validate_payload(schema, {"model": "m", "prompt": "p", "extra": True})
+        with self.assertRaises(atlas.AtlasError):
+            atlas.validate_payload(schema, {"model": "m", "prompt": "p", "aspect_ratio": "2:1"})
+
+    @patch.object(atlas, "request_json")
+    def test_submit_once_makes_one_post(self, request_json):
+        request_json.return_value = {"code": 200, "data": {"id": "pred-1", "status": "created"}}
+        result = atlas.submit_once({"model": "m", "prompt": "p"}, "secret")
+        self.assertEqual(result["id"], "pred-1")
+        self.assertEqual(request_json.call_count, 1)
+        self.assertEqual(request_json.call_args.kwargs["method"], "POST")
+
+    @patch.object(atlas, "request_json")
+    def test_submit_once_does_not_retry_api_error(self, request_json):
+        request_json.return_value = {"code": 400, "message": "invalid payload"}
+        with self.assertRaises(atlas.AtlasError):
+            atlas.submit_once({"model": "m", "prompt": "p"}, "secret")
+        self.assertEqual(request_json.call_count, 1)
+
+    @patch.object(atlas.time, "sleep")
+    @patch.object(atlas, "request_json")
+    def test_poll_retries_get_and_stops_on_completion(self, request_json, sleep):
+        request_json.side_effect = [
+            atlas.AtlasError("temporary"),
+            {"data": {"id": "pred-1", "status": "processing", "outputs": []}},
+            {"data": {"id": "pred-1", "status": "completed", "outputs": ["https://cdn.example/x.png"]}},
+        ]
+        result = atlas.poll_prediction("pred-1", "secret", attempts=3, interval=0)
+        self.assertEqual(result["status"], "completed")
+        self.assertEqual(request_json.call_count, 3)
+        self.assertEqual(sleep.call_count, 2)
+
+    def test_download_rejects_non_https(self):
+        with self.assertRaises(atlas.AtlasError):
+            atlas.download_image("http://example.com/logo.png", Path("logo.png"))
+
+    @patch.object(atlas, "validate_public_https")
+    @patch.object(atlas, "urlopen")
+    def test_download_writes_png_atomically(self, urlopen_mock, validate_url):
+        urlopen_mock.return_value = FakeResponse(
+            b"\x89PNG\r\n\x1a\n" + b"payload",
+            content_type="image/png",
+        )
+        with self.subTest("download"):
+            import tempfile
+
+            with tempfile.TemporaryDirectory() as directory:
+                output = Path(directory) / "logo.png"
+                atlas.download_image("https://cdn.example/logo.png", output)
+                self.assertTrue(output.read_bytes().startswith(b"\x89PNG"))
+        self.assertEqual(validate_url.call_count, 2)
+
+    @patch.object(atlas, "urlopen")
+    def test_request_json_sets_stable_headers(self, urlopen_mock):
+        urlopen_mock.return_value = FakeResponse({"ok": True})
+        self.assertEqual(atlas.request_json("https://example.com"), {"ok": True})
+        request = urlopen_mock.call_args.args[0]
+        self.assertEqual(request.get_header("Accept"), "application/json")
+        self.assertEqual(request.get_header("User-agent"), "opc-logo-creator/1.1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Adds Atlas Cloud as an optional image-generation provider for logo-creator while preserving the existing Nano Banana path as the default.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Enhancement to existing skill

## Changes Made

- Add a standard-library Atlas runner that validates the live model catalog and model-specific schema before every request.
- Require an explicit generation confirmation, submit exactly one potentially billable POST, bound prediction GET polling, and validate downloaded image artifacts.
- Document the provider-selection and dry-run workflow.
- Add focused tests and update the skill's plugin/marketplace metadata to 1.1.0.

## Affected Skills

- [x] logo-creator

## Testing Done

- [x] python3 -m unittest discover -s skills/logo-creator/tests -v
- [x] python3 -m py_compile skills/logo-creator/scripts/generate_atlas.py skills/logo-creator/tests/test_generate_atlas.py
- [x] Live, non-billable catalog/schema dry-run against google/nano-banana-2/text-to-image
- [x] Local npx skills add installation for logo-creator on Codex
- [x] jq empty for all changed JSON manifests
- [x] git diff --check

No generation POST was made during validation.